### PR TITLE
Fixing config URL check - shouldn't be an array, should be a single string

### DIFF
--- a/src/PostcodeAnywhere.php
+++ b/src/PostcodeAnywhere.php
@@ -128,8 +128,7 @@ class PostcodeAnywhere
         // Validate Key parameter
         if (
             !array_key_exists('url', $config) ||
-            !is_array($config['url']) ||
-            count($config['url']) < 1
+            empty($config['url'])
         ) {
             throw new \ErrorException('Web service URL is not set in config file.');
         }

--- a/src/php/PostcodeAnywhere.php
+++ b/src/php/PostcodeAnywhere.php
@@ -130,8 +130,7 @@ class PostcodeAnywhere
         // Validate Key parameter
         if (
             !array_key_exists('url', $this->config) ||
-            !is_array($this->config['url']) ||
-            count($this->config['url']) < 1
+            empty($this->config['url'])
         ) {
             throw new \ErrorException('Web service URL is not set in config file.');
         }


### PR DESCRIPTION
Hi @alexpechkarev 

In my previous merge I overlooked the fact that the URL in the config should be a string and not an array, which introduced an issue into the codebase.

This PR resolves that problem